### PR TITLE
Add bindings for Libuv 1.39.0

### DIFF
--- a/.ci/bindcov.sh
+++ b/.ci/bindcov.sh
@@ -29,7 +29,7 @@ skipped+=(
 	uv_req_type_name uv_pipe_chmod uv_process_get_pid uv_get_osfhandle
 	uv_open_osfhandle uv_fs_get_type uv_fs_get_result uv_fs_get_ptr uv_fs_get_path uv_fs_get_statbuf
 	uv_ip4_addr uv_ip6_addr uv_ip4_name uv_ip6_name uv_inet_ntop uv_inet_pton uv_dlopen uv_dlclose
-	uv_dlsym uv_dlerror uv_udp_using_recvmmsg
+	uv_dlsym uv_dlerror uv_udp_using_recvmmsg uv_fs_get_system_error
 )
 
 # get all public uv_ functions from uv.h

--- a/.ci/bindcov.sh
+++ b/.ci/bindcov.sh
@@ -7,7 +7,7 @@ skipped=()
 skipped+=(uv_thread_create uv_thread_create_ex)
 
 # intentionally not bound
-skipped+=(uv_replace_allocator)
+skipped+=(uv_replace_allocator uv_library_shutdown)
 
 # threading/synchronization
 skipped+=(
@@ -29,7 +29,7 @@ skipped+=(
 	uv_req_type_name uv_pipe_chmod uv_process_get_pid uv_get_osfhandle
 	uv_open_osfhandle uv_fs_get_type uv_fs_get_result uv_fs_get_ptr uv_fs_get_path uv_fs_get_statbuf
 	uv_ip4_addr uv_ip6_addr uv_ip4_name uv_ip6_name uv_inet_ntop uv_inet_pton uv_dlopen uv_dlclose
-	uv_dlsym uv_dlerror
+	uv_dlsym uv_dlerror uv_udp_using_recvmmsg
 )
 
 # get all public uv_ functions from uv.h

--- a/docs.md
+++ b/docs.md
@@ -107,6 +107,7 @@ are relevant to behavior seen in the Lua module.
 - [DNS utility functions][]
 - [Threading and synchronization utilities][]
 - [Miscellaneous utilities][]
+- [Metrics operations][]
 
 ## Error Handling
 
@@ -216,6 +217,8 @@ Supported options:
   This operation is currently only implemented for `"sigprof"` signals, to suppress
   unnecessary wakeups when using a sampling profiler. Requesting other signals will
   fail with `EINVAL`.
+  - `"metrics_idle_time"`: Accumulate the amount of idle time the event loop spends
+  in the event provider. This option is necessary to use `metrics_idle_time()`.
 
 An example of a valid call to this function is:
 
@@ -3465,6 +3468,23 @@ low on entropy.
 **Returns (sync version):** `string` or `fail`
 
 **Returns (async version):** `0` or `fail`
+
+## Metrics operations
+
+[Metrics operations]: #metrics-operations
+
+### `uv.metrics_idle_time()`
+
+Retrieve the amount of time the event loop has been idle in the kernel’s event
+provider (e.g. `epoll_wait`). The call is thread safe.
+
+The return value is the accumulated time spent idle in the kernel’s event
+provider starting from when the [`uv_loop_t`][] was configured to collect the idle time.
+
+**Note:** The event loop will not begin accumulating the event provider’s idle
+time until calling `loop_configure` with `"metrics_idle_time"`.
+
+**Returns:** `number`
 
 ---
 

--- a/src/loop.c
+++ b/src/loop.c
@@ -97,7 +97,11 @@ static int luv_walk(lua_State* L) {
 
 #if LUV_UV_VERSION_GEQ(1, 0, 2)
 static const char *const luv_loop_configure_options[] = {
-  "block_signal", NULL
+  "block_signal",
+#if LUV_UV_VERSION_GEQ(1, 39, 0)
+  "metrics_idle_time",
+#endif
+  NULL
 };
 
 static int luv_loop_configure(lua_State* L) {
@@ -106,6 +110,9 @@ static int luv_loop_configure(lua_State* L) {
   int ret = 0;
   switch (luaL_checkoption(L, 1, NULL, luv_loop_configure_options)) {
   case 0: option = UV_LOOP_BLOCK_SIGNAL; break;
+#if LUV_UV_VERSION_GEQ(1, 39, 0)
+  case 1: option = UV_METRICS_IDLE_TIME; break;
+#endif
   default: break; /* unreachable */
   }
   if (option == UV_LOOP_BLOCK_SIGNAL) {
@@ -114,6 +121,8 @@ static int luv_loop_configure(lua_State* L) {
     luaL_argcheck(L, lua_isstring(L, 2), 2, "block_signal option: expected signal as string or number");
     signal = luv_parse_signal(L, 2);
     ret = uv_loop_configure(loop, UV_LOOP_BLOCK_SIGNAL, signal);
+  } else {
+    ret = uv_loop_configure(loop, option);
   }
   return luv_result(L, ret);
 }

--- a/src/luv.c
+++ b/src/luv.c
@@ -48,6 +48,7 @@
 #include "work.c"
 #include "misc.c"
 #include "constants.c"
+#include "metrics.c"
 
 static const luaL_Reg luv_functions[] = {
   // loop.c
@@ -369,6 +370,11 @@ static const luaL_Reg luv_functions[] = {
   // util.c
 #if LUV_UV_VERSION_GEQ(1, 10, 0)
   {"translate_sys_error", luv_translate_sys_error},
+#endif
+
+  // metrics.c
+#if LUV_UV_VERSION_GEQ(1, 39, 0)
+  {"metrics_idle_time", luv_metrics_idle_time},
 #endif
 
   {NULL, NULL}

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2014 The Luvit Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "luv.h"
+#include "util.h"
+
+#if LUV_UV_VERSION_GEQ(1, 39, 0)
+static int luv_metrics_idle_time(lua_State* L) {
+  uint64_t idle_time = uv_metrics_idle_time(luv_loop(L));
+  lua_pushinteger(L, idle_time);
+  return 1;
+}
+#endif

--- a/tests/manual-test-metrics.lua
+++ b/tests/manual-test-metrics.lua
@@ -1,0 +1,27 @@
+-- This is a manual test because uv.loop_configure would affect all other tests that
+-- run after it. So, just to be safe, this is not included in the automatic test runner.
+
+return require('lib/tap')(function (test)
+
+  -- port of https://github.com/libuv/libuv/blob/fa8b4f27c023638918e645ef997c3b56a3a5e681/test/test-metrics.c#L39-L63
+  test("idle time", function (print, p, expect, uv)
+    local NS_TO_MS = 1000000
+    local timeout = 1000
+    uv.loop_configure('metrics_idle_time')
+    local timer = uv.new_timer()
+    local counter = 0
+    timer:start(timeout, 0, function()
+      counter = counter + 1
+      local t = uv.hrtime()
+
+      -- Spin for 500 ms to spin loop time out of the delta check.
+      while uv.hrtime() - t < 600 * NS_TO_MS do end
+      timer:close()
+
+      local idle_time = uv.metrics_idle_time()
+      assert(idle_time <= (timeout + 500) * NS_TO_MS, "idle_time larger than expected: "..idle_time)
+      assert(idle_time >= (timeout - 500) * NS_TO_MS, "idle_time smaller than expected: "..idle_time)
+    end)
+  end)
+
+end)


### PR DESCRIPTION
- Skips uv_library_shutdown and uv_udp_using_recvmmsg bindings in bindcov.sh
- Adds binding for uv_metrics_idle_time
- updates uv_loop_configure binding to support UV_METRICS_IDLE_TIME
- Adds a manual test for metrics_idle_time