### PR TITLE
Fix thread_{get,set}affinity passing `luv_thread_t*` to libuv instead of `uv_thread_t*`

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -394,7 +394,7 @@ static int luv_thread_getaffinity(lua_State* L) {
     return luaL_argerror(L, 2, lua_pushfstring(L, "cpumask size must be >= %d (from cpumask_size()), got %d", default_mask_size, mask_size));
   }
   char* cpumask = malloc(mask_size);
-  int ret = uv_thread_getaffinity(tid, cpumask, mask_size);
+  int ret = uv_thread_getaffinity(&tid->handle, cpumask, mask_size);
   if (ret < 0) {
     free(cpumask);
     return luv_error(L, ret);
@@ -428,7 +428,7 @@ static int luv_thread_setaffinity(lua_State* L) {
     lua_pop(L, 1);
   }
   char* oldmask = get_old_mask ? malloc(mask_size) : NULL;
-  int ret = uv_thread_setaffinity(tid, cpumask, oldmask, mask_size);
+  int ret = uv_thread_setaffinity(&tid->handle, cpumask, oldmask, mask_size);
   // Done with cpumask at this point
   free(cpumask);
   if (ret < 0) {


### PR DESCRIPTION
This happened to work since the uv_thread_t is at the start of the luv_thread_t structs so their pointers happen to be equal, but it's definitely worth fixing.